### PR TITLE
Three more 'clean_nicely' exits

### DIFF
--- a/src/clean.c
+++ b/src/clean.c
@@ -18,14 +18,10 @@ void	clean_nicely(t_game *game, char *error_message)
 		// 	close(game->fd);
 		delete_images(game);
 		
-		if (game->mapdata)
-		{
-			free(game->mapdata);
-			game->mapdata = NULL;
-		}
 		if (game->mlx)
 		 	mlx_terminate(game->mlx); //causes seg fault??
 		free(game->data);
+		free(game->mapdata);
 		free(game->ray);
 		free(game);
 	}

--- a/src/init.c
+++ b/src/init.c
@@ -8,9 +8,7 @@ void init_map(t_game *game)
 
 	game->mapdata = malloc(game->data->map_data.rows * game->data->map_data.cols * sizeof(char) + 1);
 	if (!game->mapdata)
-	{
-		exit(EXIT_FAILURE);
-	}
+		clean_nicely(game, "Out of memory");
 	index = 0;
 	row = 0;
 	while (row < game->data->map_data.rows)

--- a/src/main.c
+++ b/src/main.c
@@ -47,6 +47,7 @@ static void allocate_structures(t_game **pgame)
 	{
 		(*pgame)->data = malloc(sizeof(t_data));
 		(*pgame)->ray = ft_calloc(1, sizeof(t_ray));
+		(*pgame)->mapdata = NULL;
 		(*pgame)->mlx = NULL;
 		(*pgame)->stats = NULL;
 		(*pgame)->scene = NULL;
@@ -92,13 +93,13 @@ int	main(int argc, char *argv[])
 	//printf ("main: player angle is %f\n", data->player.angle);
 	game->mlx = mlx_init(SCREEN_WIDTH, SCREEN_HEIGHT, "Ray caster", true);
 	if (!game->mlx)
-		return (EXIT_FAILURE);
+		clean_nicely(game, "Failed to initialize MLX42");
 	mlx_get_monitor_size(0, &width, &height);
 	//printf ("width is %d, height is %d\n", width, height);
 	
 	game->scene = mlx_new_image(game->mlx, SCREEN_WIDTH, SCREEN_HEIGHT);
 	if (!game->scene || (mlx_image_to_window(game->mlx, game->scene, X_START, Y_START ) < 0))
-		return (EXIT_FAILURE);
+		clean_nicely(game, "Failed to create/copy an MLX42 image");
 	if(game->is_mmap)
 		print_stats(game);
 	mlx_loop_hook(game->mlx, draw_all, game);


### PR DESCRIPTION
Three `clean_nicely` function calls exits replacing `return (EXIT_FAILURE);` statements. They should have been included in yesterday's *PR*.