### PR TITLE
Tweak to memory cleaning from a failed 'data' malloc

### DIFF
--- a/src/clean.c
+++ b/src/clean.c
@@ -14,14 +14,12 @@ void	clean_nicely(t_game *game, char *error_message)
 	//free_map_grid
 	if (game)
 	{
-		// if (game->fd != -1)
-		// 	close(game->fd);
+		if (game->data)
+			free(game->data->mapdata);
+		free(game->data);
 		delete_images(game);
-		
 		if (game->mlx)
 		 	mlx_terminate(game->mlx); //causes seg fault??
-		free(game->data->mapdata);
-		free(game->data);
 		free(game->ray);
 		free(game);
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -44,12 +44,12 @@ void draw_all(void *param)
 static void allocate_structures(t_game **pgame)
 {
 	*pgame = malloc(sizeof(t_game));
-
 	if (*pgame)
 	{
 		(*pgame)->data = malloc(sizeof(t_data));
 		(*pgame)->ray = ft_calloc(1, sizeof(t_ray));
-		(*pgame)->data->mapdata = NULL;
+		if ((*pgame)->data)
+			(*pgame)->data->mapdata = NULL;
 		(*pgame)->mlx = NULL;
 		(*pgame)->stats = NULL;
 		(*pgame)->scene = NULL;


### PR DESCRIPTION
A failed `data` allocation would result in indirection errors during the cleaning