### PR TITLE
'temp' variables are not being freed

### DIFF
--- a/src/stats.c
+++ b/src/stats.c
@@ -34,11 +34,11 @@ void print_stats(t_game *game)
 	str = ft_strjoin_free(str, "PI X: ", 1);
 	temp = ft_itoa(((game->player.p_pos.x) - X_START) / CONST);  //if fails free stuff
 	if (temp)
-		str = ft_strjoin_free(str, temp, 1);
+		str = ft_strjoin_free(str, temp, 3);
 	str = ft_strjoin_free(str, " Y: ", 1);
 	temp = ft_itoa(((game->player.p_pos.y) - Y_START) / CONST);  //if fails, free stuff
 	if (temp)
-		str = ft_strjoin_free(str, temp, 1);
+		str = ft_strjoin_free(str, temp, 3);
 	game->stats = mlx_put_string(game->mlx, str, 10, 10);
 	free(str);
 


### PR DESCRIPTION
Going through the code, I noticed two temporary strings were not being freed in the `print_stats` function of **src/stats.c**.