### PR TITLE
Unable to solve Issue #19, text stats "malloc"ed on every frame

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,22 +1,23 @@
 #include "../inc/game.h"
-#include <assert.h>
-void draw_all(void *param)
-{
-	t_game *game;
-	game = (t_game *)param;
-	uint8_t *pixel;
 
+static void	clear_image(mlx_image_t *image, uint32_t npixels)
+{
+	uint8_t	*pixel;
+
+	pixel = image->pixels;
+	while (pixel - image->pixels < npixels)
+		*pixel++ &= 0xFFFFFF00;
+}
+
+void	draw_all(void *param)
+{
+	t_game *const	game = (t_game *)param;
 
 	cast_rays(game);
 	if (game->is_mmap)
 	{
-		//printf("width: %u\n", game->mini->width);
-		//assert(game->mini->width == 19);
-		const uint32_t npixels = (game->mini->width)* (game->mini->height) *  CONST;
-		pixel = game->mini->pixels;
-		while (pixel - game->mini->pixels < npixels)
-			*pixel++ &= 0xFFFFFF00;
-		
+		clear_image(game->mini,
+			(uint32_t)((game->mini->width) * (game->mini->height) * CONST));
 		
 		// printf ("drawing grid\n");
 		int i = 0;
@@ -38,10 +39,10 @@ void draw_all(void *param)
 		//printf ("player angle %f\n", game->player.angle);
 		draw_grid(game, game->data->map_data.rows, game->data->map_data.cols);
 		draw_player_direction(game, (t_pos){game->camera.pos.x, game->camera.pos.y}, game->player.angle);
-	
+
+		mlx_delete_image(game->mlx, game->stats);
+		print_stats(game);
 	}
-	mlx_delete_image(game->mlx, game->stats);
-	print_stats(game);
 }
 
 static void	allocate_structures(t_game **pgame)
@@ -57,7 +58,6 @@ static void	allocate_structures(t_game **pgame)
 		}
 		(*pgame)->ray = ft_calloc(1, sizeof(t_ray));
 		(*pgame)->mlx = NULL;
-		(*pgame)->stats = NULL;
 		(*pgame)->mini = NULL;
 		(*pgame)->scene = NULL;
 		(*pgame)->textures[E] = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -58,6 +58,7 @@ static void	allocate_structures(t_game **pgame)
 		}
 		(*pgame)->ray = ft_calloc(1, sizeof(t_ray));
 		(*pgame)->mlx = NULL;
+		(*pgame)->stats = NULL;
 		(*pgame)->mini = NULL;
 		(*pgame)->scene = NULL;
 		(*pgame)->textures[E] = NULL;


### PR DESCRIPTION
Unfortunately, the only way to solve the issue is to entirely drop the `game->stats` text-image and print unto the minimap itself, `game->mini`. That is quite an easy fix: forgo the `mlx_put_string` function call in **stats.c** file and actually print ourselves with the interesting `mlx_draw_char` function [found in **MLX42/src/font/mlx_font.c** of the MLX library]. And so I did, only to get a compiler error as the afore mentioned `mlx_draw_char` is declared `static` in the bloody library. :facepalm: 

Closes #19 

So the only code changes this *PR* introduces are minute tweaks in the `draw_all` function of **main.c**. Currently these have no effect, but I can imagine them to be necessary for a future minimap ON/OFF toggle. And they might be helpful for *Norminette* too.