### PR TITLE
Makefile with header prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ clean:
 fclean: clean
 	@make -C $(LIBFT_DIR) fclean >/dev/null
 	@rm -rf $(MLX_DIR)/build
+	@echo "$(CYAN)Removing MLX build!$(RESET)"
 	@echo "$(CYAN)Cleaning $(NAME)!$(RESET)"
 	@rm -f $(NAME)
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ LDFLAGS = -ldl -lglfw -pthread -lm
 
 NAME = cub3D
 
+HDR = inc/game.h
+
 SRC =	src/main.c src/line.c src/mmap.c src/player.c src/hooks.c src/clean.c \
 		src/stats.c src/color.c src/rays.c src/intersections.c src/scene.c \
 		src/utils.c src/init.c src/horizontal.c src/vertical.c src/mous3.c \
@@ -20,29 +22,28 @@ MLX_DIR = libs/MLX42
 LIB_MLX = $(MLX_DIR)/build/libmlx42.a
 LIBFT = $(LIBFT_DIR)/libft.a
 
-.PHONY: all clean fclean re
+.PHONY: all clean fclean re libft
 
 all: $(NAME)
 
-
-#(NAME): $(OBJ) $(LIBFT) $(LIB_MLX)
-$(NAME): $(LIB_MLX) $(LIBFT) $(OBJ)
+$(NAME): $(LIB_MLX) libft $(OBJ)
 	@$(CC) $(CFLAGS) -o $(NAME) $(OBJ) $(LIBFT) $(LIB_MLX) $(LDFLAGS)
-#	@$(CC) $(CFLAGS) -o $(NAME) $(OBJ) $(LIB_MLX) $(LDFLAGS)
 	@echo "$(DGREEN)Finished building $@!$(RESET)"
 
-$(OBJ_DIR)/%.o: src/%.c
+$(OBJ_DIR)/%.o: src/%.c $(HDR)
 	@mkdir -p $(dir $@)  # Ensure the directory for the object file exists
-	@echo "$(TEAL)Compiling $@ from $^...$(RESET)"
-	@$(CC) $(CFLAGS) -c -o $@ $^
+	@echo "$(TEAL)Compiling $@ from $<...$(RESET)"
+	@$(CC) $(CFLAGS) -c $< -o $@
 
- $(LIBFT):
-	@make -C $(LIBFT_DIR)
+$(addprefix $(OBJ_DIR)/,lexer.o parser.o map_parser.o): src/lexer_parser.h
+
+libft:
+	@make -s -C $(LIBFT_DIR)
 
 $(LIB_MLX):
 	@cmake $(MLX_DIR) -B $(MLX_DIR)/build
-	@make -C $(MLX_DIR)/build -j4
-	
+	@cmake --build $(MLX_DIR)/build -j4
+
 clean:
 	@make -C $(LIBFT_DIR) clean >/dev/null
 	@echo "$(PINK)Cleaning $(OBJ)!$(RESET)"
@@ -50,6 +51,7 @@ clean:
 
 fclean: clean
 	@make -C $(LIBFT_DIR) fclean >/dev/null
+	@rm -rf $(MLX_DIR)/build
 	@echo "$(CYAN)Cleaning $(NAME)!$(RESET)"
 	@rm -f $(NAME)
 

--- a/libs/libft/Makefile
+++ b/libs/libft/Makefile
@@ -6,7 +6,7 @@
 #    By: rtorrent <rtorrent@student.42barcel>       +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/05/09 20:52:16 by rtorrent          #+#    #+#              #
-#    Updated: 2025/03/07 18:32:06 by rtorrent       ########   odam.nl         #
+#    Updated: 2025/03/26 16:19:37 by rtorrent       ########   odam.nl         #
 #                                                                              #
 # **************************************************************************** #
 
@@ -69,7 +69,7 @@ $(NAME):: $(MKFILE)
 	@if [ -f "$@" ]; then $(MAKE) fclean; fi
 
 $(NAME):: $(OBJ)
-	$(AR) $@ $?
+	@$(AR) $@ $?
 
 clean:
 	$(RM) $(OBJ)


### PR DESCRIPTION
- **Make** now recompiles all source files whenever the **game.h** header is modified. It also contains a new rule for the three lexer/parser files that depend on the **lexer_parser.h** header.
- **Make** now recognizes changes to the **libft** source files and headers.
- `make fclean` now removes the **libs/MLX/build** folder, in addition to the usual stuff (*.obj* files, **libft.a**, and the project's executable **cub3D**).

Closes #15 